### PR TITLE
Changed from local time to UTC to match VSTS API

### DIFF
--- a/src/Common/react/Components/IterationRenderer.tsx
+++ b/src/Common/react/Components/IterationRenderer.tsx
@@ -9,8 +9,8 @@ export interface IIterationRendererProps {
 }
 
 function getMMDD(date: Date) {
-    var mm = date.getMonth() < 9 ? "0" + (date.getMonth() + 1) : (date.getMonth() + 1); // getMonth() is zero-based
-    var dd = date.getDate() < 10 ? "0" + date.getDate() : date.getDate();
+    var mm = date.getUTCMonth() < 9 ? "0" + (date.getUTCMonth() + 1) : (date.getUTCMonth() + 1); // getMonth() is zero-based
+    var dd = date.getUTCDate() < 10 ? "0" + date.getUTCDate() : date.getUTCDate();
     return `${mm}/${dd}`;
 }
 


### PR DESCRIPTION
This is a fix for #32. This happens when the VSTS instance is configured to use a different time zone than UTC. The VSTS API returns in UTC, and the local conversion was causing a day offset.