### PR TITLE
Add message bar to promote Portfolio Plans

### DIFF
--- a/src/Common/react/Components/PromotePortfolioPlans.tsx
+++ b/src/Common/react/Components/PromotePortfolioPlans.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { MessageBar, MessageBarType } from "office-ui-fabric-react/lib/MessageBar";
+import { MessageBarButton } from "office-ui-fabric-react/lib/Button";
+
+export const PromotePortfolioPlans = () => {
+    return (
+        <MessageBar
+            messageBarType={MessageBarType.info}
+            isMultiline={false}
+            actions={
+                <div>
+                    <MessageBarButton
+                        onClick={() => {
+                            const webContext = VSS.getWebContext();
+
+                            const collectionUri = webContext.collection.uri;
+                            const projectName = webContext.project.name;
+
+                            const targerUrl = `${collectionUri}${projectName}/_apps/hub/ms-devlabs.workitem-feature-timeline-extension-dev.workitem-portfolio-planning`;
+
+                            VSS.getService<IHostNavigationService>(VSS.ServiceIds.Navigation).then(
+                                client => client.navigate(targerUrl),
+                                error => alert(error)
+                            );
+                        }}
+                    >
+                        Try it now!
+                    </MessageBarButton>
+                </div>
+            }
+        >
+            <div>{"Track epics across projects and teams in the Portfolio Plans hub."}</div>
+        </MessageBar>
+    );
+};

--- a/src/Common/react/Components/PromotePortfolioPlans.tsx
+++ b/src/Common/react/Components/PromotePortfolioPlans.tsx
@@ -2,11 +2,16 @@ import * as React from "react";
 import { MessageBar, MessageBarType } from "office-ui-fabric-react/lib/MessageBar";
 import { MessageBarButton } from "office-ui-fabric-react/lib/Button";
 
-export const PromotePortfolioPlans = () => {
+export interface IPromotePortfolioPlansBanner {
+    onDismiss: () => void;
+}
+
+export const PromotePortfolioPlansBanner = (props: IPromotePortfolioPlansBanner) => {
     return (
         <MessageBar
             messageBarType={MessageBarType.info}
             isMultiline={false}
+            onDismiss={props.onDismiss}
             actions={
                 <div>
                     <MessageBarButton
@@ -22,6 +27,8 @@ export const PromotePortfolioPlans = () => {
                                 client => client.navigate(targerUrl),
                                 error => alert(error)
                             );
+
+                            props.onDismiss();
                         }}
                     >
                         Try it now!

--- a/src/Common/redux/modules/SettingsState/SettingsStateActions.ts
+++ b/src/Common/redux/modules/SettingsState/SettingsStateActions.ts
@@ -7,6 +7,7 @@ export const ChangeProgressTrackingCriteriaType = "@@common/changeprogresstracki
 export const ChangeShowClosedSinceDaysType = "@@common/changeshowclosedsincedays";
 export const RestoreSettingsType = "@@common/restoresettings";
 export const SelectEpicType = "@@common/selectepic";
+export const DismissPortfolioPlansBannerType = "@@common/dismissportfolioplansbanner";
 
 export interface ToggleShowWorkItemDetailsAction extends Action {
     type: "@@common/toggleshowworkitemdetails",
@@ -31,9 +32,13 @@ export interface SelectEpicAction extends Action {
     type: "@@common/selectepic",
     payload: number;
 }
+export interface DismissPortfolioPlansBannerAction extends Action {
+    type: "@@common/dismissportfolioplansbanner"
+    payload: undefined;
+}
 
 export type SettingsActions = ToggleShowWorkItemDetailsAction | ChangeProgressTrackingCriteriaAction
-    | RestoreSettingsAction | ChangeShowClosedSinceDaysAction | SelectEpicAction;
+    | RestoreSettingsAction | ChangeShowClosedSinceDaysAction | SelectEpicAction | DismissPortfolioPlansBannerAction;
 
 export const toggleShowWorkItemDetails: ActionCreator<ToggleShowWorkItemDetailsAction> = (show: boolean) => ({
     type: ToggleShowWorkitemDetailsType,
@@ -60,3 +65,8 @@ export const restoreSettingsState: ActionCreator<RestoreSettingsAction> = (state
     type: RestoreSettingsType,
     payload: state
 });
+
+export const dismissPortfolioPlansBanner: ActionCreator<DismissPortfolioPlansBannerAction> = () => ({
+    type: DismissPortfolioPlansBannerType,
+    payload: undefined
+})

--- a/src/Common/redux/modules/SettingsState/SettingsStateContracts.ts
+++ b/src/Common/redux/modules/SettingsState/SettingsStateContracts.ts
@@ -8,6 +8,7 @@ export interface ISettingsState {
     progressTrackingCriteria: ProgressTrackingCriteria;
     showClosedSinceDays: number;
     lastEpicSelected?: number;
+    dismissedPortfolioPlansBanner: boolean;
 }
 
 export interface ISettingsAwareState {

--- a/src/Common/redux/modules/SettingsState/SettingsStateReducer.ts
+++ b/src/Common/redux/modules/SettingsState/SettingsStateReducer.ts
@@ -1,5 +1,5 @@
 import produce from "immer";
-import { RestoreSettingsType, ToggleShowWorkitemDetailsType, ChangeProgressTrackingCriteriaType, ChangeShowClosedSinceDaysType, SettingsActions, SelectEpicType } from "./SettingsStateActions";
+import { RestoreSettingsType, ToggleShowWorkitemDetailsType, ChangeProgressTrackingCriteriaType, ChangeShowClosedSinceDaysType, SettingsActions, SelectEpicType, DismissPortfolioPlansBannerType } from "./SettingsStateActions";
 import { ISettingsState, ProgressTrackingCriteria } from "./SettingsStateContracts";
 
 export const getDefaultSettingsState = (): ISettingsState => {
@@ -7,7 +7,8 @@ export const getDefaultSettingsState = (): ISettingsState => {
         showWorkItemDetails: false,
         progressTrackingCriteria: 0,
         showClosedSinceDays: 0,
-        lastEpicSelected: undefined
+        lastEpicSelected: undefined,
+        dismissedPortfolioPlansBanner: false
     };
 }
 export function settingsStateReducer(state: ISettingsState = getDefaultSettingsState(), action: SettingsActions): ISettingsState {
@@ -34,6 +35,9 @@ export function settingsStateReducer(state: ISettingsState = getDefaultSettingsS
                 break;
             case SelectEpicType:
                 draft.lastEpicSelected = payload as number;
+                break;
+            case DismissPortfolioPlansBannerType:
+                draft.dismissedPortfolioPlansBanner = true;
                 break;
         }
     });

--- a/src/EpicRoadmap/react/Components/EpicRoadmapView.tsx
+++ b/src/EpicRoadmap/react/Components/EpicRoadmapView.tsx
@@ -1,6 +1,5 @@
 import { initializeIcons } from 'office-ui-fabric-react/lib/Icons';
 import { MessageBar, MessageBarType } from 'office-ui-fabric-react/lib/MessageBar';
-//import { MessageBar, MessageBarType } from 'office-ui-fabric-react/lib/MessageBar';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import * as React from 'react';
 import { connect, Provider } from 'react-redux';
@@ -16,7 +15,8 @@ import { WorkItem } from 'TFS/WorkItemTracking/Contracts';
 import { launchWorkItemForm } from '../../../Common/redux/actions/launchWorkItemForm';
 import { SimpleWorkItem } from '../../../Common/react/Components/WorkItem/SimpleWorkItem';
 import { Callout } from 'office-ui-fabric-react/lib/Callout';
-import { PromotePortfolioPlans } from '../../../Common/react/Components/PromotePortfolioPlans';
+import { PromotePortfolioPlansBanner } from '../../../Common/react/Components/PromotePortfolioPlans';
+import { dismissPortfolioPlansBanner } from '../../../Common/redux/modules/SettingsState/SettingsStateActions';
 
 initializeIcons(/* optional base url */);
 
@@ -26,6 +26,8 @@ export interface IEpicRoadmapViewProps {
     uiState: UIStatus;
     outOfScopeWorkItems: WorkItem[];
     launchWorkItemForm: (id: number) => void;
+    portfolioPlansBannerDismissed: boolean;
+    dismissPortfolioPlansBanner: () => void;
 }
 
 export interface IEpicRoadmapViewContentState {
@@ -113,13 +115,16 @@ class EpicRoadmapViewContent extends React.Component<IEpicRoadmapViewProps, IEpi
         }
 
         return (
-            <div className="epic-container">
-                <PromotePortfolioPlans />
-                {showSelector && <EpicSelector />}
-                {additionalMessage}
-                {callout}
-                {contents}
-            </div>
+            <>
+                {!this.props.portfolioPlansBannerDismissed &&
+                <PromotePortfolioPlansBanner onDismiss={this.props.dismissPortfolioPlansBanner}/>}
+                <div className="epic-container">
+                    {showSelector && <EpicSelector />}
+                    {additionalMessage}
+                    {callout}
+                    {contents}
+                </div>
+            </>
         );
     }
 
@@ -174,7 +179,8 @@ const makeMapStateToProps = () => {
             projectId: getProjectId(),
             teamId: getTeamId(),
             uiState: uiStateSelector(state),
-            outOfScopeWorkItems: outOfScopeWorkItems(state)
+            outOfScopeWorkItems: outOfScopeWorkItems(state),
+            portfolioPlansBannerDismissed: state.settingsState.dismissedPortfolioPlansBanner
         }
     }
 }
@@ -186,6 +192,9 @@ const mapDispatchToProps = () => {
                 if (id) {
                     dispatch(launchWorkItemForm(id));
                 }
+            },
+            dismissPortfolioPlansBanner: () => {
+                dispatch(dismissPortfolioPlansBanner())
             }
         }
     }

--- a/src/EpicRoadmap/react/Components/EpicRoadmapView.tsx
+++ b/src/EpicRoadmap/react/Components/EpicRoadmapView.tsx
@@ -16,7 +16,7 @@ import { WorkItem } from 'TFS/WorkItemTracking/Contracts';
 import { launchWorkItemForm } from '../../../Common/redux/actions/launchWorkItemForm';
 import { SimpleWorkItem } from '../../../Common/react/Components/WorkItem/SimpleWorkItem';
 import { Callout } from 'office-ui-fabric-react/lib/Callout';
-import { MessageBarButton } from 'office-ui-fabric-react/lib/Button';
+import { PromotePortfolioPlans } from '../../../Common/react/Components/PromotePortfolioPlans';
 
 initializeIcons(/* optional base url */);
 
@@ -103,19 +103,6 @@ class EpicRoadmapViewContent extends React.Component<IEpicRoadmapViewProps, IEpi
             );
         }
 
-        const promotePortfolioPlans = (
-            <MessageBar
-                messageBarType={MessageBarType.info}
-                isMultiline={false}
-                actions={
-                    <div>
-                        <MessageBarButton onClick={this._navigateToPortfolioPlans}>Try it now!</MessageBarButton>
-                    </div>
-                }>
-                    <div>{"Track epics across projects and teams in the Portfolio Plans hub."}</div>
-            </MessageBar>
-        )
-
         if (uiState === UIStatus.Default || uiState === UIStatus.OutofScopeTeamIterations) {
             contents = <EpicRoadmapGrid />;
         }
@@ -127,26 +114,12 @@ class EpicRoadmapViewContent extends React.Component<IEpicRoadmapViewProps, IEpi
 
         return (
             <div className="epic-container">
+                <PromotePortfolioPlans />
                 {showSelector && <EpicSelector />}
                 {additionalMessage}
-                {promotePortfolioPlans}
                 {callout}
                 {contents}
             </div>
-        );
-    }
-
-    private _navigateToPortfolioPlans() {
-        const webContext = VSS.getWebContext();
-
-        const collectionUri = webContext.collection.uri;
-        const projectName = webContext.project.name;
-
-        const targerUrl = `${collectionUri}${projectName}/_apps/hub/ms-devlabs.workitem-feature-timeline-extension-dev.workitem-portfolio-planning`;
-
-        VSS.getService<IHostNavigationService>(VSS.ServiceIds.Navigation).then(
-            client => client.navigate(targerUrl),
-            error => alert(error)
         );
     }
 

--- a/src/EpicRoadmap/react/Components/EpicRoadmapView.tsx
+++ b/src/EpicRoadmap/react/Components/EpicRoadmapView.tsx
@@ -16,6 +16,7 @@ import { WorkItem } from 'TFS/WorkItemTracking/Contracts';
 import { launchWorkItemForm } from '../../../Common/redux/actions/launchWorkItemForm';
 import { SimpleWorkItem } from '../../../Common/react/Components/WorkItem/SimpleWorkItem';
 import { Callout } from 'office-ui-fabric-react/lib/Callout';
+import { MessageBarButton } from 'office-ui-fabric-react/lib/Button';
 
 initializeIcons(/* optional base url */);
 
@@ -102,6 +103,19 @@ class EpicRoadmapViewContent extends React.Component<IEpicRoadmapViewProps, IEpi
             );
         }
 
+        const promotePortfolioPlans = (
+            <MessageBar
+                messageBarType={MessageBarType.info}
+                isMultiline={false}
+                actions={
+                    <div>
+                        <MessageBarButton onClick={this._navigateToPortfolioPlans}>Try it now!</MessageBarButton>
+                    </div>
+                }>
+                    <div>{"Track epics across projects and teams in the Portfolio Plans hub."}</div>
+            </MessageBar>
+        )
+
         if (uiState === UIStatus.Default || uiState === UIStatus.OutofScopeTeamIterations) {
             contents = <EpicRoadmapGrid />;
         }
@@ -115,9 +129,24 @@ class EpicRoadmapViewContent extends React.Component<IEpicRoadmapViewProps, IEpi
             <div className="epic-container">
                 {showSelector && <EpicSelector />}
                 {additionalMessage}
+                {promotePortfolioPlans}
                 {callout}
                 {contents}
             </div>
+        );
+    }
+
+    private _navigateToPortfolioPlans() {
+        const webContext = VSS.getWebContext();
+
+        const collectionUri = webContext.collection.uri;
+        const projectName = webContext.project.name;
+
+        const targerUrl = `${collectionUri}${projectName}/_apps/hub/ms-devlabs.workitem-feature-timeline-extension-dev.workitem-portfolio-planning`;
+
+        VSS.getService<IHostNavigationService>(VSS.ServiceIds.Navigation).then(
+            client => client.navigate(targerUrl),
+            error => alert(error)
         );
     }
 

--- a/src/EpicRoadmap/redux/sagas/watchEpicRoadmapSagaActions.ts
+++ b/src/EpicRoadmap/redux/sagas/watchEpicRoadmapSagaActions.ts
@@ -2,7 +2,7 @@ import { takeEvery, takeLatest } from "redux-saga/effects";
 import { OverrideIterationEndType, SaveOverrideIterationActionType } from "../../../Common/redux/modules/overrideIterationProgress/overrideIterationProgressActions";
 import { launchOverrideWorkItemIteration, launchSaveOverrideIteration, launchClearOverrideIteration } from "../../../Common/redux/sagas/workItemOverrideIterationListner";
 import { DisplayAllIterationsActionType, ShiftDisplayIterationLeftActionType, ShiftDisplayIterationRightActionType, ChangeDisplayIterationCountActionType } from "../../../Common/redux/modules/IterationDisplayOptions/IterationDisplayOptionsActions";
-import { ToggleShowWorkitemDetailsType, ChangeProgressTrackingCriteriaType, ChangeShowClosedSinceDaysType, SelectEpicType } from "../../../Common/redux/modules/SettingsState/SettingsStateActions";
+import { ToggleShowWorkitemDetailsType, ChangeProgressTrackingCriteriaType, ChangeShowClosedSinceDaysType, SelectEpicType, DismissPortfolioPlansBannerType } from "../../../Common/redux/modules/SettingsState/SettingsStateActions";
 import { saveDisplayOptions } from "../../../Common/redux/sagas/displayOptionsSaga";
 import { saveSettings } from "../../../Common/redux/modules/SettingsState/SettingsStateSagas";
 import { LaunchWorkItemFormActionType } from "../../../Common/redux/actions/launchWorkItemForm";
@@ -31,6 +31,7 @@ export function* watchEpicRoadmapSagaActions() {
     yield takeLatest(ChangeProgressTrackingCriteriaType, saveSettings, "EpicRoadmap");
     yield takeLatest(ChangeShowClosedSinceDaysType, saveSettings, "EpicRoadmap");
     yield takeLatest(SelectEpicType, saveSettings, "EpicRoadmap");
+    yield takeLatest(DismissPortfolioPlansBannerType, saveSettings, "EpicRoadmap");
 
     yield takeLatest(EpicsMetadataAvailable, FetchEpicsSaga);
 }

--- a/src/FeatureTimeline/react/Components/FeatureTimelineGrid.tsx
+++ b/src/FeatureTimeline/react/Components/FeatureTimelineGrid.tsx
@@ -38,6 +38,7 @@ import { IFeatureTimelineRawState, IPlanFeaturesState } from '../../redux/store/
 import { startMarkInProgress } from '../../redux/store/workitems/actionCreators';
 import './FeatureTimelineGrid.scss';
 import { FeatureTimelineDialog } from './FeatureTimelineDialog';
+import { PromotePortfolioPlans } from '../../../Common/react/Components/PromotePortfolioPlans';
 
 initializeIcons(/* optional base url */);
 
@@ -511,6 +512,7 @@ export class FeatureTimelineGrid extends React.Component<IFeatureTimelineGridPro
 
         return (
             <div className="root-container">
+                <PromotePortfolioPlans />
                 {commands}
                 {<div className="header-gap"></div>}
                 {contents}

--- a/src/FeatureTimeline/react/Components/FeatureTimelineGrid.tsx
+++ b/src/FeatureTimeline/react/Components/FeatureTimelineGrid.tsx
@@ -26,7 +26,7 @@ import { changeDisplayIterationCount, displayAllIterations, shiftDisplayIteratio
 import { saveOverrideIteration, endOverrideIteration, overrideHoverOverIteration, startOverrideIteration } from '../../../Common/redux/modules/overrideIterationProgress/overrideIterationProgressActionCreators';
 import { IWorkItemOverrideIteration } from '../../../Common/redux/modules/OverrideIterations/overriddenIterationContracts';
 import { OverriddenIterationsActionCreator } from '../../../Common/redux/modules/OverrideIterations/overrideIterationsActions';
-import { changeProgressTrackingCriteria, changeShowClosedSinceDays, toggleShowWorkItemDetails } from '../../../Common/redux/modules/SettingsState/SettingsStateActions';
+import { changeProgressTrackingCriteria, changeShowClosedSinceDays, toggleShowWorkItemDetails, dismissPortfolioPlansBanner } from '../../../Common/redux/modules/SettingsState/SettingsStateActions';
 import { ISettingsState, ProgressTrackingCriteria } from "../../../Common/redux/modules/SettingsState/SettingsStateContracts";
 import { getSettingsState } from '../../../Common/redux/modules/SettingsState/SettingsStateSelector';
 import { closeDetails, showDetails } from '../../../Common/redux/modules/ShowHideDetails/ShowHideDetailsActions';
@@ -38,7 +38,7 @@ import { IFeatureTimelineRawState, IPlanFeaturesState } from '../../redux/store/
 import { startMarkInProgress } from '../../redux/store/workitems/actionCreators';
 import './FeatureTimelineGrid.scss';
 import { FeatureTimelineDialog } from './FeatureTimelineDialog';
-import { PromotePortfolioPlans } from '../../../Common/react/Components/PromotePortfolioPlans';
+import { PromotePortfolioPlansBanner } from '../../../Common/react/Components/PromotePortfolioPlans';
 
 initializeIcons(/* optional base url */);
 
@@ -70,6 +70,7 @@ export interface IFeatureTimelineGridProps {
     toggleShowWorkItemDetails: (show: boolean) => void;
     changeProgressTrackingCriteria: (criteria: ProgressTrackingCriteria) => void;
     changeShowClosedSinceDays: (days: number) => void;
+    dismissPortfolioPlansBanner: () => void;
 }
 
 const makeMapStateToProps = () => {
@@ -147,6 +148,9 @@ const mapDispatchToProps = (dispatch) => {
         },
         resizePlanFeaturesPane: (width: number) => {
             dispatch(changePlanFeaturesWidth(width));
+        },
+        dismissPortfolioPlansBanner: () => {
+            dispatch(dismissPortfolioPlansBanner())
         }
     };
 };
@@ -512,7 +516,8 @@ export class FeatureTimelineGrid extends React.Component<IFeatureTimelineGridPro
 
         return (
             <div className="root-container">
-                <PromotePortfolioPlans />
+                {!this.props.settingsState.dismissedPortfolioPlansBanner && 
+                <PromotePortfolioPlansBanner onDismiss={this.props.dismissPortfolioPlansBanner}/>}
                 {commands}
                 {<div className="header-gap"></div>}
                 {contents}

--- a/src/FeatureTimeline/redux/sagas/index.ts
+++ b/src/FeatureTimeline/redux/sagas/index.ts
@@ -16,7 +16,7 @@ import { ClearOverrideIterationType } from '../../../Common/redux/modules/Overri
 import { LaunchWorkItemFormActionType } from "../../../Common/redux/actions/launchWorkItemForm";
 import { OverrideIterationEndType, SaveOverrideIterationActionType } from "../../../Common/redux/modules/overrideIterationProgress/overrideIterationProgressActions";
 import { DisplayAllIterationsActionType, ShiftDisplayIterationLeftActionType, ShiftDisplayIterationRightActionType, ChangeDisplayIterationCountActionType } from "../../../Common/redux/modules/IterationDisplayOptions/IterationDisplayOptionsActions";
-import { ToggleShowWorkitemDetailsType, ChangeProgressTrackingCriteriaType, ChangeShowClosedSinceDaysType } from "../../../Common/redux/modules/SettingsState/SettingsStateActions";
+import { ToggleShowWorkitemDetailsType, ChangeProgressTrackingCriteriaType, ChangeShowClosedSinceDaysType, DismissPortfolioPlansBannerType } from "../../../Common/redux/modules/SettingsState/SettingsStateActions";
 
 export function* watchSagaActions() {
     yield takeEvery(ClearOverrideIterationType, launchClearOverrideIteration);
@@ -37,6 +37,7 @@ export function* watchSagaActions() {
     yield takeLatest(ToggleShowWorkitemDetailsType, saveSettings, "");
     yield takeLatest(ChangeProgressTrackingCriteriaType, saveSettings, "");
     yield takeLatest(ChangeShowClosedSinceDaysType, saveSettings, "");
+    yield takeLatest(DismissPortfolioPlansBannerType, saveSettings, "");
 
     yield takeLatest(TogglePlanFeaturesPaneType, savePlanFeaturesDisplayOptions);
     yield takeLatest(PlanFeaturesPaneFilterChangedType, savePlanFeaturesDisplayOptions);

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "workitem-feature-timeline-extension",
-    "version": "0.0.343",
+    "version": "0.0.344",
     "name": "Feature timeline and Epic Roadmap",
     "description": "Feature timeline of your in-progress features.",
     "publisher": "ms-devlabs",


### PR DESCRIPTION
- Added a message bar on both Feature Timeline and Epic Roadmap
- Banner has a button that navigates to Portfolio Plans hub
- Once dismissed it won't show up for that user in that project

Alternatively we could just leave the banner there and not store it in the settings. We could just remove it after a couple weeks. I'll let Navneet Gupta make a call on that. I'm going on vacation but feel free to merge this once Navneet is back.

![image](https://user-images.githubusercontent.com/30058280/61320171-b93dbf80-a7bd-11e9-90d3-44361b893576.png)
