### PR TITLE
Portfolio plans - only in hosted env

### DIFF
--- a/configs/dev.json
+++ b/configs/dev.json
@@ -1,4 +1,5 @@
 {
     "public": false,
+    "baseUri": "https://localhost:8888",
     "name": "Feature timeline  (DEV)"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,118 @@
       "resolved": "https://registry.npmjs.org/@interactjs/utils/-/utils-1.4.14.tgz",
       "integrity": "sha512-yx+COkmoJzzPBkG6alUtWXbOHLuivjyE6X0HG1x/ViDbY3uOdC59GN5qeQVBk0+ydoOvv98x/gYYIcPllCh94A=="
     },
+    "@microsoft/applicationinsights-analytics-js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.1.0.tgz",
+      "integrity": "sha512-iQ+wqBbMePf5NsG59NkJ/KRtoO5CXdYzcp6ZwYbvl/RTIrqrr2FtwIcS/gSiTITlpvuL65PXFffOhl0KGzdoEQ==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.1.0",
+        "@microsoft/applicationinsights-core-js": "2.1.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
+      }
+    },
+    "@microsoft/applicationinsights-channel-js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.1.0.tgz",
+      "integrity": "sha512-bquayqFv0KNJ+Rxln/07Z2iY989BZdJ5qtaKkoRuqOIG2W0hCbisQZOV9qpF4aPYib3gn+KtQqL41XyH6PMb2w==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.1.0",
+        "@microsoft/applicationinsights-core-js": "2.1.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
+      }
+    },
+    "@microsoft/applicationinsights-common": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.1.0.tgz",
+      "integrity": "sha512-m1OIvHm6XaqHm/CdfxuZ6xy5mcEcXkf22trCWRmAvf3IXH27+Jm3F/+6y37Nd8cd013IBLioVLMwUBQ9t2mXEg==",
+      "requires": {
+        "@microsoft/applicationinsights-core-js": "2.1.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
+      }
+    },
+    "@microsoft/applicationinsights-core-js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.1.0.tgz",
+      "integrity": "sha512-gSEj51HCeKepS6Yb7kJBlaolQJtUXnFjzubZjX1ZZW/sxdRK5d1jVNPIVWK3nVU53ydcpE/9VmWhG2nf6v7kdg==",
+      "requires": {
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
+      }
+    },
+    "@microsoft/applicationinsights-dependencies-js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.1.0.tgz",
+      "integrity": "sha512-v/NlvVmpB7FtGeJ8J6zcZwBonAlWDnxRTme01Jdfy3NV7+L1tFzdUke7cjxzCQ+4/QEImM80tIFMgd0bfQ98DQ==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.1.0",
+        "@microsoft/applicationinsights-core-js": "2.1.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
+      }
+    },
+    "@microsoft/applicationinsights-properties-js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.1.0.tgz",
+      "integrity": "sha512-NtINizsZaQMOQvp5Wb7kLWlQ/VBwvtkkaC8PHyJC0yaHJ6o1Dls2FI6eQsmT1L01btlrPDeu1M2v6QWbTbf2uQ==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.1.0",
+        "@microsoft/applicationinsights-core-js": "2.1.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
+      }
+    },
+    "@microsoft/applicationinsights-web": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.1.0.tgz",
+      "integrity": "sha512-YEhCIdfA95u9RnBfwR181RqNq0FmkairdBvNwG0za9tLCjIs+WIXxQBucuhZEbzOl63bWuDNrggavRBx01QKzw==",
+      "requires": {
+        "@microsoft/applicationinsights-analytics-js": "2.1.0",
+        "@microsoft/applicationinsights-channel-js": "2.1.0",
+        "@microsoft/applicationinsights-common": "2.1.0",
+        "@microsoft/applicationinsights-core-js": "2.1.0",
+        "@microsoft/applicationinsights-dependencies-js": "2.1.0",
+        "@microsoft/applicationinsights-properties-js": "2.1.0"
+      }
+    },
     "@microsoft/load-themed-styles": {
       "version": "1.7.69",
       "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.69.tgz",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "clean": "rimraf dist *.vsix vss-extension-release.json src/*js libs",
     "dev:webpack": "webpack --watch",
-    "dev": "webpack-dev-server --hot --progress --colors --content-base ./dist --https --port 8888",
+    "dev": "webpack-dev-server --hot --progress --colors --content-base ./ --https --port 8888",
     "dev:http": "webpack-dev-server --progress --colors --content-base ./ --port 8888",
     "package:dev": "node ./scripts/packageDev",
     "package:dev:http": "node ./scripts/packageDevHttp",

--- a/scripts/packageDev.js
+++ b/scripts/packageDev.js
@@ -5,7 +5,7 @@ var manifest = require("../vss-extension.json");
 var extensionId = manifest.id;
 
 // Package extension
-var command = `tfx extension create --rev-version --overrides-file configs/dev.json --manifest-globs vss-extension.json --extension-id ${extensionId}-dev --no-prompt`;
+var command = `tfx extension create --overrides-file configs/dev.json --manifest-globs vss-extension.json --extension-id ${extensionId}-dev --no-prompt`;
 exec(command, function (error) {
     if (error) {
         console.log(`Package create error: ${error}`);

--- a/scripts/packageDevHttp.js
+++ b/scripts/packageDevHttp.js
@@ -6,6 +6,10 @@ var extensionId = manifest.id;
 
 // Package extension
 var command = `tfx extension create --overrides-file configs/devHttp.json --manifest-globs vss-extension.json --extension-id ${extensionId}-dev --no-prompt`;
-exec(command, function() {
-    console.log("Package created");
+exec(command, function (error) {
+    if (error) {
+        console.log(`Package create error: ${error}`);
+    } else {
+        console.log("Package created");
+    }
 });

--- a/src/Common/react/Components/PromotePortfolioPlans.tsx
+++ b/src/Common/react/Components/PromotePortfolioPlans.tsx
@@ -20,8 +20,9 @@ export const PromotePortfolioPlansBanner = (props: IPromotePortfolioPlansBanner)
 
                             const collectionUri = webContext.collection.uri;
                             const projectName = webContext.project.name;
+                            const extensionContext = VSS.getExtensionContext()
 
-                            const targerUrl = `${collectionUri}${projectName}/_apps/hub/ms-devlabs.workitem-feature-timeline-extension-dev.workitem-portfolio-planning`;
+                            const targerUrl = `${collectionUri}${projectName}/_apps/hub/${extensionContext.publisherId}.${extensionContext.extensionId}.workitem-portfolio-planning`;
 
                             VSS.getService<IHostNavigationService>(VSS.ServiceIds.Navigation).then(
                                 client => client.navigate(targerUrl),

--- a/src/PortfolioPlanning/Common/ODataClient.ts
+++ b/src/PortfolioPlanning/Common/ODataClient.ts
@@ -1,5 +1,6 @@
 import { authTokenManager } from "VSS/Authentication/Services";
 import { GUIDUtil } from "./Utilities/GUIDUtil";
+import { ExtensionConstants } from "../Contracts";
 /// <reference types='jquery' />
 /// <reference types='jqueryui' />
 
@@ -36,15 +37,14 @@ export class ODataClient {
     }
 
     public getODataEndpoint(accountName: string, projectName: string): string {
-        const collectionUri = VSS.getWebContext().collection.uri;
         const projectSegment = projectName != null ? `${projectName}/` : "";
+        const extensionId = VSS.getExtensionContext().extensionId;
 
-        if (
-            collectionUri.toLowerCase().indexOf("localhost") !== -1 ||
-            collectionUri.toLowerCase().indexOf("defaultcollection") !== -1
-        ) {
-            //  Hack to construct OData endpoint based on deployment type (hosted vs onprem).
-            return `${collectionUri}${projectSegment}_odata/${ODataClient.oDataVersion}/`;
+        if (extensionId.toLowerCase() !== ExtensionConstants.EXTENSION_ID.toLowerCase()) {
+            //  Local dev environment.
+            return `https://analytics.codedev.ms/${accountName}/${projectSegment}_odata/${
+                ODataClient.oDataVersion
+            }/`;
         } else {
             return `https://analytics.dev.azure.com/${accountName}/${projectSegment}_odata/${
                 ODataClient.oDataVersion

--- a/src/PortfolioPlanning/Contracts.ts
+++ b/src/PortfolioPlanning/Contracts.ts
@@ -82,3 +82,8 @@ export enum LoadingStatus {
     NotLoaded,
     Loaded
 }
+
+export class ExtensionConstants
+{
+    public static EXTENSION_ID: string = "workitem-feature-timeline-extension";
+}

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -70,7 +70,15 @@
                 "uri": "dist/PortfolioPlanning.html",
                 "dynamic": true,
                 "icon": "dist/images/portfolio-plans-icon.png"
-            }
+            },
+            "constraints": [
+                {
+                    "name": "ExecutionEnvironment",
+                    "properties": {
+                        "hosted": true
+                    }
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Portfolio plans hub will only be available in hosted environments.
OData support for Descendants is not yet enabled in DevOps Server 2019, so we are just excluding the hub from OnPrem.
To run inner dev loop in DevFabric, I had to make some changes to the scripts (e.g. server files in https).