### PR TITLE
Navigating to epic roadmap

### DIFF
--- a/src/PortfolioPlanning/Common/Components/ODataTest.tsx
+++ b/src/PortfolioPlanning/Common/Components/ODataTest.tsx
@@ -139,6 +139,7 @@ export class ODataTest extends React.Component<{}, ODataTestState> {
                                         //  Update plan to include information for two projects.
                                         planRetrieved.projects["FBED1309-56DB-44DB-9006-24AD73EEE785"] = {
                                             ProjectId: "FBED1309-56DB-44DB-9006-24AD73EEE785",
+                                            PortfolioBacklogLevelName: "Epics",
                                             PortfolioWorkItemType: "Epic",
                                             RequirementWorkItemType: "User Story",
                                             EffortODataColumnName: "StoryPoints",
@@ -148,6 +149,7 @@ export class ODataTest extends React.Component<{}, ODataTestState> {
 
                                         planRetrieved.projects["6974D8FE-08C8-4123-AD1D-FB830A098DFB"] = {
                                             ProjectId: "6974D8FE-08C8-4123-AD1D-FB830A098DFB",
+                                            PortfolioBacklogLevelName: "Epics",
                                             PortfolioWorkItemType: "Epic",
                                             RequirementWorkItemType: "User Story",
                                             EffortODataColumnName: "StoryPoints",

--- a/src/PortfolioPlanning/Common/Services/PortfolioPlanningDataService.ts
+++ b/src/PortfolioPlanning/Common/Services/PortfolioPlanningDataService.ts
@@ -29,6 +29,7 @@ import { GUIDUtil } from "../Utilities/GUIDUtil";
 import { ProjectConfiguration } from "../../../PortfolioPlanning/Models/ProjectBacklogModels";
 import { IdentityRef } from "VSS/WebApi/Contracts";
 import { defaultProjectComparer } from "../Utilities/Comparers";
+import { BacklogConfigurationDataService } from "./BacklogConfigurationDataService";
 
 export class PortfolioPlanningDataService {
     private static _instance: PortfolioPlanningDataService;
@@ -114,19 +115,46 @@ export class PortfolioPlanningDataService {
     }
 
     public async loadPortfolioContent(
-        portfolioQueryInput: PortfolioPlanningQueryInput
+        portfolioQueryInput: PortfolioPlanningQueryInput,
+        backlogLevelNameByProject: { [projectId: string]: string }
     ): Promise<PortfolioPlanningFullContentQueryResult> {
         const projectsQueryInput: PortfolioPlanningProjectQueryInput = {
             projectIds: portfolioQueryInput.WorkItems.map(workItems => workItems.projectId)
         };
 
+        if (!backlogLevelNameByProject) {
+            backlogLevelNameByProject = {};
+        }
+
+        const projectIdsWithNoBacklogLevelName: string[] = [];
+        Object.keys(backlogLevelNameByProject).forEach(projectId => {
+            if (!backlogLevelNameByProject[projectId]) {
+                projectIdsWithNoBacklogLevelName.push(projectId);
+            }
+        });
+
+        if (projectIdsWithNoBacklogLevelName && projectIdsWithNoBacklogLevelName.length > 0) {
+            //  Some stored plans don't have information for backlog level name.
+            const missingProjectConfigs = await Promise.all(
+                projectIdsWithNoBacklogLevelName.map(projectId =>
+                    BacklogConfigurationDataService.getInstance().getProjectBacklogConfiguration(projectId)
+                )
+            );
+
+            missingProjectConfigs.forEach(projectConfig => {
+                backlogLevelNameByProject[projectConfig.projectId.toLowerCase()] = projectConfig.epicBacklogLevelName;
+            });
+        }
+
         const projectConfigurations: { [projectId: string]: ProjectConfiguration } = {};
         portfolioQueryInput.WorkItems.forEach(wi => {
             const projectKey = wi.projectId.toLowerCase();
+            const backlogLevelName = backlogLevelNameByProject[projectKey];
 
             if (!projectConfigurations[projectKey]) {
                 projectConfigurations[projectKey] = {
                     projectId: projectKey,
+                    epicBacklogLevelName: backlogLevelName,
                     defaultEpicWorkItemType: wi.WorkItemTypeFilter,
                     defaultRequirementWorkItemType: wi.DescendantsWorkItemTypeFilter,
                     effortFieldRefName: wi.EffortWorkItemFieldRefName,

--- a/src/PortfolioPlanning/Components/Plan/AddItemPanel.tsx
+++ b/src/PortfolioPlanning/Components/Plan/AddItemPanel.tsx
@@ -238,6 +238,7 @@ export class AddItemPanel extends React.Component<IAddItemPanelProps, IAddItemPa
             projectId: this.state.selectedProject.id,
             itemIdsToAdd: this.state.selectedEpics,
             workItemType: this.state.selectedProjectBacklogConfiguration.defaultEpicWorkItemType,
+            epicBacklogLevelName: this.state.selectedProjectBacklogConfiguration.epicBacklogLevelName,
             requirementWorkItemType: this.state.selectedProjectBacklogConfiguration.defaultRequirementWorkItemType,
             effortWorkItemFieldRefName: this.state.selectedProjectBacklogConfiguration.effortFieldRefName
         });

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
@@ -278,13 +278,15 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps> {
 
     private navigateToEpicRoadmap(item: ITimelineItem) {
         const collectionUri = VSS.getWebContext().collection.uri;
+        const extensionContext = VSS.getExtensionContext();
         const projectName = item.group;
         const teamId = item.teamId;
-        //  TODO    Need to get the backlog level somewhere....
-        const backlogLevel = "Epics";
+        const backlogLevel = item.backlogLevel;
         const workItemId = item.id;
 
-        const targerUrl = `${collectionUri}${projectName}/_backlogs/ms-devlabs.workitem-feature-timeline-extension-dev.workitem-epic-roadmap/${teamId}/${backlogLevel}#${workItemId}`;
+        const targerUrl = `${collectionUri}${projectName}/_backlogs/${extensionContext.publisherId}.${
+            extensionContext.extensionId
+        }.workitem-epic-roadmap/${teamId}/${backlogLevel}#${workItemId}`;
 
         VSS.getService<IHostNavigationService>(VSS.ServiceIds.Navigation).then(
             client => {

--- a/src/PortfolioPlanning/Contracts.ts
+++ b/src/PortfolioPlanning/Contracts.ts
@@ -7,6 +7,12 @@ export interface IProject {
 
 export interface IProjectConfiguration {
     id: string;
+
+    /**
+     * Name of the Epic backlog level. Used for navigation to epic roadmap.
+     */
+    epicBacklogLevelName: string;
+
     /**
      * Default work item type associated to the Microsoft.EpicCategory portfolio backlog level for the project.
      */
@@ -31,6 +37,7 @@ export interface IEpic {
     id: number;
     project: string;
     teamId: string;
+    backlogLevel: string;
     title: string;
     startDate?: Date;
     endDate?: Date;
@@ -50,6 +57,7 @@ export interface IAddItems {
     projectId: string;
     itemIdsToAdd: number[];
     workItemType: string;
+    epicBacklogLevelName: string;
     requirementWorkItemType: string;
     effortWorkItemFieldRefName: string;
 }
@@ -68,6 +76,7 @@ export interface ITimelineItem {
     id: number;
     group: string;
     teamId: string;
+    backlogLevel: string;
     title: string;
     start_time: moment.Moment;
     end_time: moment.Moment;

--- a/src/PortfolioPlanning/Models/PortfolioPlanningQueryModels.ts
+++ b/src/PortfolioPlanning/Models/PortfolioPlanningQueryModels.ts
@@ -83,6 +83,7 @@ export interface PortfolioPlanning extends PortfolioPlanningMetadata {
 export interface ProjectPortfolioPlanning {
     ProjectId: string;
     PortfolioWorkItemType: string;
+    PortfolioBacklogLevelName: string;
     RequirementWorkItemType: string;
     EffortODataColumnName: string;
     EffortWorkItemFieldRefName: string;

--- a/src/PortfolioPlanning/Models/ProjectBacklogModels.ts
+++ b/src/PortfolioPlanning/Models/ProjectBacklogModels.ts
@@ -2,6 +2,11 @@ export interface ProjectBacklogConfiguration {
     projectId: string;
 
     /**
+     * Name of the Epic backlog level. Used for navigation to epic roadmap.
+     */
+    epicBacklogLevelName: string;
+
+    /**
      * Default work item type associated to the Microsoft.EpicCategory portfolio backlog level for the project.
      */
     defaultEpicWorkItemType: string;

--- a/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
@@ -196,6 +196,7 @@ function handlePortfolioItemsReceived(
 
                 draft.projectConfiguration[projectIdKeyLowercase] = {
                     id: projectIdKeyLowercase,
+                    epicBacklogLevelName: projectConfig.epicBacklogLevelName,
                     defaultEpicWorkItemType: projectConfig.defaultEpicWorkItemType,
                     defaultRequirementWorkItemType: projectConfig.defaultRequirementWorkItemType,
                     effortWorkItemFieldRefName: projectConfig.effortFieldRefName,
@@ -210,8 +211,13 @@ function handlePortfolioItemsReceived(
                         ? teamAreas.teamsInArea[item.AreaId][0].teamId
                         : null;
 
+                const backlogLevelName: string = projects.projectConfigurations[item.ProjectId]
+                    ? projects.projectConfigurations[item.ProjectId].epicBacklogLevelName
+                    : null;
+
                 return {
                     id: item.WorkItemId,
+                    backlogLevel: backlogLevelName,
                     project: item.ProjectId,
                     teamId: teamIdValue,
                     title: item.Title,
@@ -257,6 +263,7 @@ function handlePortfolioItemsReceived(
 
                     draft.projectConfiguration[newProjectIdLowercase] = {
                         id: newProjectIdLowercase,
+                        epicBacklogLevelName: projectConfig.epicBacklogLevelName,
                         defaultEpicWorkItemType: projectConfig.defaultEpicWorkItemType,
                         defaultRequirementWorkItemType: projectConfig.defaultRequirementWorkItemType,
                         effortWorkItemFieldRefName: projectConfig.effortFieldRefName,
@@ -276,8 +283,13 @@ function handlePortfolioItemsReceived(
                             ? teamAreas.teamsInArea[newItemInfo.AreaId][0].teamId
                             : null;
 
+                    const backlogLevelName: string = projects.projectConfigurations[newItemInfo.ProjectId]
+                        ? projects.projectConfigurations[newItemInfo.ProjectId].epicBacklogLevelName
+                        : null;
+
                     draft.epics.push({
                         id: newItemInfo.WorkItemId,
+                        backlogLevel: backlogLevelName,
                         project: newItemInfo.ProjectId,
                         teamId: teamIdValue,
                         title: newItemInfo.Title,

--- a/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
@@ -66,6 +66,7 @@ function* onAddEpics(action: ActionsOfType<EpicTimelineActions, EpicTimelineActi
             //  TODO    Once "Add Epic Dialog" uses redux, project configuration will be available in the state,
             //          so there won't be a need to pass these values when adding epics.
             workItemType,
+            epicBacklogLevelName,
             requirementWorkItemType,
             effortWorkItemFieldRefName
             //  END of TODO
@@ -92,6 +93,7 @@ function* onAddEpics(action: ActionsOfType<EpicTimelineActions, EpicTimelineActi
 
             projectConfig = {
                 id: projectIdLowerCase,
+                epicBacklogLevelName: epicBacklogLevelName,
                 defaultEpicWorkItemType: workItemType,
                 defaultRequirementWorkItemType: requirementWorkItemType,
                 effortWorkItemFieldRefName: effortWorkItemFieldRefName,
@@ -108,6 +110,7 @@ function* onAddEpics(action: ActionsOfType<EpicTimelineActions, EpicTimelineActi
         if (!storedPlan.projects[projectIdLowerCase]) {
             storedPlan.projects[projectIdLowerCase] = {
                 ProjectId: projectConfig.id,
+                PortfolioBacklogLevelName: projectConfig.epicBacklogLevelName,
                 PortfolioWorkItemType: projectConfig.defaultEpicWorkItemType,
                 RequirementWorkItemType: projectConfig.defaultRequirementWorkItemType,
                 EffortWorkItemFieldRefName: projectConfig.effortWorkItemFieldRefName,
@@ -137,7 +140,8 @@ function* onAddEpics(action: ActionsOfType<EpicTimelineActions, EpicTimelineActi
 
         const queryResult: PortfolioPlanningFullContentQueryResult = yield effects.call(
             [portfolioService, portfolioService.loadPortfolioContent],
-            portfolioQueryInput
+            portfolioQueryInput,
+            { [projectIdLowerCase]: projectConfig.epicBacklogLevelName }
         );
 
         yield effects.call(SetDefaultDatesForEpics, queryResult);

--- a/src/PortfolioPlanning/Redux/Selectors/EpicTimelineSelectors.ts
+++ b/src/PortfolioPlanning/Redux/Selectors/EpicTimelineSelectors.ts
@@ -69,6 +69,7 @@ export function getTimelineItems(state: IEpicTimelineState): ITimelineItem[] {
             id: epic.id,
             group: epic.project,
             teamId: epic.teamId,
+            backlogLevel: epic.backlogLevel,
             title: epic.title,
             start_time: moment(epic.startDate),
             end_time: moment(epic.endDate),


### PR DESCRIPTION
This version does not call the `BacklogConfigurationDataService` on every click to load the backlog name.

I also added logic to save the backlog level name to the plan's storage, and for existing plans that do not have it, `loadPortfolio` fixes it.