### PR TITLE
0.0.346 - Updated docs

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "workitem-feature-timeline-extension",
-    "version": "0.0.345",
+    "version": "0.0.346",
     "name": "Feature timeline and Epic Roadmap",
     "description": "Feature timeline of your in-progress features.",
     "publisher": "ms-devlabs",


### PR DESCRIPTION
Update extension documentation to mention that `Portfolio Plans` is only supported in `Azure DevOps Services`