### PR TITLE
Moving some OData queries to POST

### DIFF
--- a/src/PortfolioPlanning/Models/PortfolioPlanningQueryModels.ts
+++ b/src/PortfolioPlanning/Models/PortfolioPlanningQueryModels.ts
@@ -36,7 +36,7 @@ export interface PortfolioPlanningQueryResultItem {
 }
 
 export interface PortfolioPlanningProjectQueryInput {
-    projectIds: string[];
+    projects: { [projectId: string]: boolean };
 }
 
 export interface PortfolioPlanningProjectQueryResult extends IQueryResultError {
@@ -142,7 +142,7 @@ export interface PortfolioPlanningTeamsInAreaQueryInput {
     /**
      * AreaIds by project id.
      */
-    [projectId: string]: string[];
+    [projectId: string]: { [areaId: string]: boolean };
 }
 
 export interface PortfolioPlanningTeamsInAreaQueryResult extends IQueryResultError {


### PR DESCRIPTION
A customer reported an issue when opening a plan. After investigation, OData calls to get projects and work items areas information failed due to the URL size. These calls were using `HttpMethod GET`.

Solution is to switch to `POST` method for queries whose payload can exceed supported size.

Also added request header Analytics team asked for (`x-tfs-session`).