### PR TITLE
Fix undefined planid type error.

### DIFF
--- a/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
@@ -192,10 +192,8 @@ export default class PlanPage extends React.Component<IPlanPageProps, IPortfolio
     };
 
     private _backButtonClicked = (): void => {
-        if (this.props.planLoadingStatus === LoadingStatus.Loaded) {
-            this.props.toggleSelectedPlanId(undefined);
-            this.props.resetPlanState();
-        }
+        this.props.toggleSelectedPlanId(undefined);
+        this.props.resetPlanState();
     };
 
     private _deletePlanButtonClicked = (): void => {

--- a/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
@@ -192,8 +192,10 @@ export default class PlanPage extends React.Component<IPlanPageProps, IPortfolio
     };
 
     private _backButtonClicked = (): void => {
-        this.props.toggleSelectedPlanId(undefined);
-        this.props.resetPlanState();
+        if (this.props.planLoadingStatus === LoadingStatus.Loaded) {
+            this.props.toggleSelectedPlanId(undefined);
+            this.props.resetPlanState();
+        }
     };
 
     private _deletePlanButtonClicked = (): void => {

--- a/src/PortfolioPlanning/Redux/Actions/PlanDirectoryActions.ts
+++ b/src/PortfolioPlanning/Redux/Actions/PlanDirectoryActions.ts
@@ -43,8 +43,8 @@ export const PlanDirectoryActions = {
         PortfolioTelemetry.getInstance().TrackAction(PlanDirectoryActionTypes.DeletePlan);
         return createAction(PlanDirectoryActionTypes.DeletePlan, { id });
     },
-    updateProjectsAndTeamsMetadata: (projectNames: string[], teamNames: string[]) =>
-        createAction(PlanDirectoryActionTypes.UpdateProjectsAndTeamsMetadata, { projectNames, teamNames }),
+    updateProjectsAndTeamsMetadata: (planId:string, projectNames: string[], teamNames: string[]) =>
+        createAction(PlanDirectoryActionTypes.UpdateProjectsAndTeamsMetadata, { planId, projectNames, teamNames }),
     toggleSelectedPlanId: (id: string) => {
         PortfolioTelemetry.getInstance().TrackAction(PlanDirectoryActionTypes.ToggleSelectedPlanId);
         return createAction(PlanDirectoryActionTypes.ToggleSelectedPlanId, {

--- a/src/PortfolioPlanning/Redux/Reducers/PlanDirectoryReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/PlanDirectoryReducer.ts
@@ -38,9 +38,9 @@ export function planDirectoryReducer(state: IPlanDirectoryState, action: PlanDir
                 break;
             }
             case PlanDirectoryActionTypes.UpdateProjectsAndTeamsMetadata: {
-                const { projectNames, teamNames } = action.payload;
+                const { planId, projectNames, teamNames } = action.payload;
 
-                const planToUpdate = draft.plans.find(plan => plan.id === draft.selectedPlanId);
+                const planToUpdate = draft.plans.find(plan => plan.id === planId);
 
                 planToUpdate.projectNames = projectNames;
                 planToUpdate.teamNames = teamNames;

--- a/src/PortfolioPlanning/Redux/Sagas/PlanDirectorySaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/PlanDirectorySaga.ts
@@ -73,9 +73,9 @@ function* deletePlan(action: ActionsOfType<PlanDirectoryActions, PlanDirectoryAc
 function* updateProjectsAndTeamsMetadata(): SagaIterator {
     try {
         const exceptionMessage = yield effects.select(getExceptionMessage);
+        const planId = yield effects.select(getSelectedPlanId);
 
-        if (!exceptionMessage) {
-            const planId = yield effects.select(getSelectedPlanId);
+        if (!exceptionMessage && planId) {
             const projectNames = yield effects.select(getProjectNames);
             const teamNames = yield effects.select(getTeamNames);
 
@@ -122,6 +122,7 @@ function* updateProjectsAndTeamsMetadata(): SagaIterator {
 
                 yield effects.put(
                     PlanDirectoryActions.updateProjectsAndTeamsMetadata(
+                        planToUpdate.id,
                         planToUpdate.projectNames,
                         planToUpdate.teamNames
                     )


### PR DESCRIPTION
The reason for the error is because back button is clicked before the plan is done loading.
When clicking back button, we set selectedPlanId in store to undefined.
And for loading a plan, we dispatch below three actions:
PlanDirectory/SelectPlan
EpicTimeline/PortfolioItemsReceived
PlanDirectory/UpdateProjectsAndTeamsMetadata

So if the back action is completed before all actions take place, our program will try to find the plan to update with an undefined plan id, thus the type error.

In this PR. I have done two things.
1. check for plan id before updating projects and teams of a plan.
2. use the planToUpdate's id instead of selected plan id when updating a plan.