### PR TITLE
Disable updating an item when it's being updated in server.

### DIFF
--- a/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
@@ -144,7 +144,7 @@ export default class PlanPage extends React.Component<IPlanPageProps, IPortfolio
     };
 
     private _renderItemDetailsDialog = (): JSX.Element => {
-        if (this.props.selectedItem) {
+        if (this.props.selectedItem && this.props.selectedItem.canMove) {
             return (
                 <DetailsDialog
                     key={Date.now()} // TODO: Is there a better way to reset the state?

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
@@ -325,7 +325,8 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps, IPlanTimel
                 {...getItemProps({
                     className: "plan-timeline-item",
                     style: {
-                        background: "white",
+                        background: item.canMove?  "white" : "#f8f8f8",
+                        fontWeight: item.canMove? 600 : 900,
                         color: "black",
                         ...borderStyle,
                         borderRadius: "4px"

--- a/src/PortfolioPlanning/Contracts.ts
+++ b/src/PortfolioPlanning/Contracts.ts
@@ -70,6 +70,8 @@ export interface IWorkItem {
 
     effortProgress: number;
     countProgress: number;
+
+    itemUpdating: boolean;
 }
 
 export interface IAddItems {
@@ -103,6 +105,7 @@ export interface ITimelineItem {
     iconUrl: string;
     start_time: moment.Moment;
     end_time: moment.Moment;
+    canMove: boolean;
 }
 
 export enum ProgressTrackingCriteria {

--- a/src/PortfolioPlanning/Redux/Actions/EpicTimelineActions.ts
+++ b/src/PortfolioPlanning/Redux/Actions/EpicTimelineActions.ts
@@ -16,6 +16,7 @@ export const enum EpicTimelineActionTypes {
     UpdateStartDate = "EpicTimeline/UpdateStartDate",
     UpdateEndDate = "EpicTimeline/UpdateEndDate",
     ShiftItem = "EpicTimeline/ShiftItem",
+    UpdateItemSucceeded = "EpicTimeline/UpdateItemSucceeded",
     ToggleItemDetailsDialogHidden = "EpicTimeline/ToggleItemDetailsDialogHidden",
     SetSelectedItemId = "EpicTimeline/SetSelectedItemId",
     PortfolioItemsReceived = "EpicTimeline/PortfolioItemsReceived",
@@ -52,6 +53,9 @@ export const EpicTimelineActions = {
     shiftItem: (itemId: number, startDate: moment.Moment) => {
         PortfolioTelemetry.getInstance().TrackAction(EpicTimelineActionTypes.ShiftItem);
         return createAction(EpicTimelineActionTypes.ShiftItem, { itemId, startDate });
+    },
+    updateItemSucceeded: (itemId: number) => {
+        return createAction(EpicTimelineActionTypes.UpdateItemSucceeded, { itemId });
     },
     toggleItemDetailsDialogHidden: (hidden: boolean) =>
         createAction(EpicTimelineActionTypes.ToggleItemDetailsDialogHidden, {

--- a/src/PortfolioPlanning/Redux/Actions/EpicTimelineActions.ts
+++ b/src/PortfolioPlanning/Redux/Actions/EpicTimelineActions.ts
@@ -16,7 +16,7 @@ export const enum EpicTimelineActionTypes {
     UpdateStartDate = "EpicTimeline/UpdateStartDate",
     UpdateEndDate = "EpicTimeline/UpdateEndDate",
     ShiftItem = "EpicTimeline/ShiftItem",
-    UpdateItemSucceeded = "EpicTimeline/UpdateItemSucceeded",
+    UpdateItemFinished = "EpicTimeline/UpdateItemFinished",
     ToggleItemDetailsDialogHidden = "EpicTimeline/ToggleItemDetailsDialogHidden",
     SetSelectedItemId = "EpicTimeline/SetSelectedItemId",
     PortfolioItemsReceived = "EpicTimeline/PortfolioItemsReceived",
@@ -54,8 +54,8 @@ export const EpicTimelineActions = {
         PortfolioTelemetry.getInstance().TrackAction(EpicTimelineActionTypes.ShiftItem);
         return createAction(EpicTimelineActionTypes.ShiftItem, { itemId, startDate });
     },
-    updateItemSucceeded: (itemId: number) => {
-        return createAction(EpicTimelineActionTypes.UpdateItemSucceeded, { itemId });
+    updateItemFinished: (itemId: number) => {
+        return createAction(EpicTimelineActionTypes.UpdateItemFinished, { itemId });
     },
     toggleItemDetailsDialogHidden: (hidden: boolean) =>
         createAction(EpicTimelineActionTypes.ToggleItemDetailsDialogHidden, {

--- a/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
@@ -20,7 +20,7 @@ export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimel
 
                 epicToUpdate.startDate = startDate.toDate();
                 epicToUpdate.startDate.setHours(0, 0, 0, 0);
-
+                epicToUpdate.itemUpdating = true;
                 break;
             }
             case EpicTimelineActionTypes.UpdateEndDate: {
@@ -30,7 +30,7 @@ export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimel
 
                 epicToUpdate.endDate = endDate.toDate();
                 epicToUpdate.endDate.setHours(0, 0, 0, 0);
-
+                epicToUpdate.itemUpdating = true;
                 break;
             }
             case EpicTimelineActionTypes.ShiftItem: {
@@ -44,7 +44,13 @@ export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimel
                 epicToUpdate.startDate.setHours(0, 0, 0, 0);
                 epicToUpdate.endDate = startDate.add(epicDuration, "milliseconds").toDate();
                 epicToUpdate.endDate.setHours(0, 0, 0, 0);
-
+                epicToUpdate.itemUpdating = true;
+                break;
+            }
+            case EpicTimelineActionTypes.UpdateItemSucceeded: {
+                const {itemId} = action.payload;
+                const epicToUpdate = draft.epics.find(epic => epic.id === itemId);
+                epicToUpdate.itemUpdating = false;
                 break;
             }
             case EpicTimelineActionTypes.ToggleItemDetailsDialogHidden: {
@@ -200,7 +206,8 @@ function handlePortfolioItemsReceived(
                     completedEffort: item.CompletedEffort,
                     totalEffort: item.TotalEffort,
                     effortProgress: item.EffortProgress,
-                    countProgress: item.CountProgress
+                    countProgress: item.CountProgress,
+                    itemUpdating: false
                 };
             });
 
@@ -269,7 +276,8 @@ function handlePortfolioItemsReceived(
                         completedEffort: newItemInfo.CompletedEffort,
                         totalEffort: newItemInfo.TotalEffort,
                         effortProgress: newItemInfo.EffortProgress,
-                        countProgress: newItemInfo.CountProgress
+                        countProgress: newItemInfo.CountProgress,
+                        itemUpdating: false
                     });
                 }
             });

--- a/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
@@ -47,7 +47,7 @@ export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimel
                 epicToUpdate.itemUpdating = true;
                 break;
             }
-            case EpicTimelineActionTypes.UpdateItemSucceeded: {
+            case EpicTimelineActionTypes.UpdateItemFinished: {
                 const {itemId} = action.payload;
                 const epicToUpdate = draft.epics.find(epic => epic.id === itemId);
                 epicToUpdate.itemUpdating = false;

--- a/src/PortfolioPlanning/Redux/Sagas/DefaultDateUtil.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/DefaultDateUtil.ts
@@ -59,7 +59,7 @@ export function* saveDatesToServer(workItemId: number, defaultStartDate?: Date, 
     const witHttpClient: WorkItemTrackingHttpClient = yield effects.call(
         [VSS_Service, VSS_Service.getClient],
         WorkItemTrackingHttpClient
-    );
+    ); 
 
     yield effects.call([witHttpClient, witHttpClient.updateWorkItem], doc, workItemId);
 

--- a/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
@@ -30,37 +30,40 @@ export function* epicTimelineSaga(): SagaIterator {
 function* onUpdateStartDate(
     action: ActionsOfType<EpicTimelineActions, EpicTimelineActionTypes.UpdateStartDate>
 ): SagaIterator {
+    const epicId = action.payload.epicId;
     try {
-        const epicId = action.payload.epicId;
         yield effects.call(saveDatesToServer, epicId);
-        yield effects.put(EpicTimelineActions.updateItemSucceeded(epicId));
     } catch (exception) {
         console.error(exception);
         yield effects.put(EpicTimelineActions.handleGeneralException(exception));
+    } finally {
+        yield effects.put(EpicTimelineActions.updateItemFinished(epicId));
     }
 }
 
 function* onUpdateEndDate(
     action: ActionsOfType<EpicTimelineActions, EpicTimelineActionTypes.UpdateEndDate>
 ): SagaIterator {
+    const epicId = action.payload.epicId;
     try {
-        const epicId = action.payload.epicId;
         yield effects.call(saveDatesToServer, epicId);
-        yield effects.put(EpicTimelineActions.updateItemSucceeded(epicId));
     } catch (exception) {
         console.error(exception);
         yield effects.put(EpicTimelineActions.handleGeneralException(exception));
+    } finally {
+        yield effects.put(EpicTimelineActions.updateItemFinished(epicId));
     }
 }
 
 function* onShiftEpic(action: ActionsOfType<EpicTimelineActions, EpicTimelineActionTypes.ShiftItem>): SagaIterator {
+    const epicId = action.payload.itemId;
     try {
-        const epicId = action.payload.itemId;
         yield effects.call(saveDatesToServer, epicId);
-        yield effects.put(EpicTimelineActions.updateItemSucceeded(epicId));
     } catch (exception) {
         console.error(exception);
         yield effects.put(EpicTimelineActions.handleGeneralException(exception));
+    } finally {
+        yield effects.put(EpicTimelineActions.updateItemFinished(epicId));
     }
 }
 function* onAddEpics(action: ActionsOfType<EpicTimelineActions, EpicTimelineActionTypes.AddItems>): SagaIterator {

--- a/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
@@ -33,6 +33,7 @@ function* onUpdateStartDate(
     try {
         const epicId = action.payload.epicId;
         yield effects.call(saveDatesToServer, epicId);
+        yield effects.put(EpicTimelineActions.updateItemSucceeded(epicId));
     } catch (exception) {
         console.error(exception);
         yield effects.put(EpicTimelineActions.handleGeneralException(exception));
@@ -45,6 +46,7 @@ function* onUpdateEndDate(
     try {
         const epicId = action.payload.epicId;
         yield effects.call(saveDatesToServer, epicId);
+        yield effects.put(EpicTimelineActions.updateItemSucceeded(epicId));
     } catch (exception) {
         console.error(exception);
         yield effects.put(EpicTimelineActions.handleGeneralException(exception));
@@ -55,6 +57,7 @@ function* onShiftEpic(action: ActionsOfType<EpicTimelineActions, EpicTimelineAct
     try {
         const epicId = action.payload.itemId;
         yield effects.call(saveDatesToServer, epicId);
+        yield effects.put(EpicTimelineActions.updateItemSucceeded(epicId));
     } catch (exception) {
         console.error(exception);
         yield effects.put(EpicTimelineActions.handleGeneralException(exception));

--- a/src/PortfolioPlanning/Redux/Selectors/EpicTimelineSelectors.ts
+++ b/src/PortfolioPlanning/Redux/Selectors/EpicTimelineSelectors.ts
@@ -71,7 +71,9 @@ export function getTimelineItems(state: IEpicTimelineState): ITimelineItem[] {
                 completed: completed,
                 total: total,
                 progress: progress
-            }
+            },
+            canMove: !epic.itemUpdating,
+            canResize: !epic.itemUpdating
         };
     });
 }


### PR DESCRIPTION
If multiple calls of updating work item being sent to server too fast, we get below error:
TF26071: This work item has been changed by someone else since you opened it.  You will need to refresh it and discard your changes.

We could go with 2 options:
1. debounce the updating work item call, only updating work items after a certain time amount. 
2. disable updating work item action if the item is being updated in server. 

In this PR, the second option is implemented.
If an item is not done updating in server, we disable editing this work item of any kind (resizing, moving, editing dates from dialog)