### PR TITLE
Chain states and dependency query to avoid timing issue.

### DIFF
--- a/src/PortfolioPlanning/Components/Plan/DependencyPanel.tsx
+++ b/src/PortfolioPlanning/Components/Plan/DependencyPanel.tsx
@@ -63,36 +63,33 @@ export class DependencyPanel extends React.Component<IDependencyPanelProps & typ
             workItemTypeMappedStatesInProgress: {}
         };
 
-        this._getDependencies().then(
-            dependencies => {
-                const projectIdKey = this.props.projectInfo.id.toLowerCase();
-                const { configuration } = this.props.projectInfo;
-                let Predecessors: PortfolioPlanningQueryResultItem[] = [];
-                let Successors: PortfolioPlanningQueryResultItem[] = [];
-
-                if (dependencies && dependencies.byProject[projectIdKey]) {
-                    Predecessors = dependencies.byProject[projectIdKey].Predecessors;
-                    Successors = dependencies.byProject[projectIdKey].Successors;
-                }
-
-                this.setState({
-                    loading: LoadingStatus.Loaded,
-                    predecessors: Predecessors,
-                    successors: Successors,
-                    workItemIcons: configuration.iconInfoByWorkItemType,
-                    errorMessage: dependencies.exceptionMessage
-                });
-            },
-            error => {
-                this.setState({ errorMessage: error.message, loading: LoadingStatus.NotLoaded });
-            }
-        );
-
         this._getWorkItemTypeMappedStatesInProgress().then(
             workItemTypeMappedStatesInProgress => {
-                this.setState({
-                    workItemTypeMappedStatesInProgress: workItemTypeMappedStatesInProgress
-                });
+                this._getDependencies().then(
+                    dependencies => {
+                        const projectIdKey = this.props.projectInfo.id.toLowerCase();
+                        const { configuration } = this.props.projectInfo;
+                        let Predecessors: PortfolioPlanningQueryResultItem[] = [];
+                        let Successors: PortfolioPlanningQueryResultItem[] = [];
+        
+                        if (dependencies && dependencies.byProject[projectIdKey]) {
+                            Predecessors = dependencies.byProject[projectIdKey].Predecessors;
+                            Successors = dependencies.byProject[projectIdKey].Successors;
+                        }
+        
+                        this.setState({
+                            loading: LoadingStatus.Loaded,
+                            predecessors: Predecessors,
+                            successors: Successors,
+                            workItemIcons: configuration.iconInfoByWorkItemType,
+                            errorMessage: dependencies.exceptionMessage,
+                            workItemTypeMappedStatesInProgress: workItemTypeMappedStatesInProgress
+                        });
+                    },
+                    error => {
+                        this.setState({ errorMessage: error.message, loading: LoadingStatus.NotLoaded });
+                    }
+                );
             },
             error => {
                 this.setState({ errorMessage: error.message, loading: LoadingStatus.NotLoaded });


### PR DESCRIPTION
When openning dependency panel, sometimes we get below error:
TypeError: Cannot read property 'indexOf' of undefined    at DependencyPanel._this._showInfoIcon (PortfolioPlanning.js:108970)

This is due to the dependencies data call comes back first, before the inprogress states call completes, in this PR, we chain them to make sure we don't have timings issues , call get inprogress states, and when that completes, then run the dependencies query.