### PR TITLE
Combine update start date and end date.

### DIFF
--- a/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanPage.tsx
@@ -206,9 +206,6 @@ const Actions = {
     onToggleProgressTrackingCriteria: EpicTimelineActions.toggleProgressTrackingCriteria,
     onCloseAddItemPanel: EpicTimelineActions.closeAddItemPanel,
     onAddItems: EpicTimelineActions.addItems,
-    onToggleSetDatesDialogHidden: EpicTimelineActions.toggleItemDetailsDialogHidden,
-    onUpdateStartDate: EpicTimelineActions.updateStartDate,
-    onUpdateEndDate: EpicTimelineActions.updateEndDate,
     onTogglePlanSettingsPanelOpen: EpicTimelineActions.togglePlanSettingsPanelOpen,
     toggleDeletePlanDialogHidden: EpicTimelineActions.toggleDeletePlanDialogHidden,
     dismissErrorMessageCard: EpicTimelineActions.dismissErrorMessageCard

--- a/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
+++ b/src/PortfolioPlanning/Components/Plan/PlanTimeline.tsx
@@ -117,8 +117,7 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps, IPlanTimel
                     endDate={this.state.contextMenuItem.end_time}
                     hidden={this.props.setDatesDialogHidden}
                     save={(id, startDate, endDate) => {
-                        this.props.onUpdateStartDate(id, startDate);
-                        this.props.onUpdateEndDate(id, endDate);
+                        this.props.onUpdateDates(id, startDate, endDate);
                     }}
                     close={() => {
                         this.props.onToggleSetDatesDialogHidden(true);
@@ -489,11 +488,12 @@ export class PlanTimeline extends React.Component<IPlanTimelineProps, IPlanTimel
     }
 
     private _onItemResize = (itemId: number, time: number, edge: string): void => {
+        const itemToUpdate = this.props.items.find(item => item.id === itemId);
         if (edge == "left") {
-            this.props.onUpdateStartDate(itemId, moment(time));
+            this.props.onUpdateDates(itemId, moment(time), itemToUpdate.end_time);
         } else {
             // "right"
-            this.props.onUpdateEndDate(itemId, moment(time));
+            this.props.onUpdateDates(itemId, itemToUpdate.start_time, moment(time));
         }
     };
 
@@ -576,8 +576,7 @@ function mapStateToProps(state: IPortfolioPlanningState): IPlanTimelineMappedPro
 }
 
 const Actions = {
-    onUpdateStartDate: EpicTimelineActions.updateStartDate,
-    onUpdateEndDate: EpicTimelineActions.updateEndDate,
+    onUpdateDates: EpicTimelineActions.updateDates,
     onShiftItem: EpicTimelineActions.shiftItem,
     onToggleSetDatesDialogHidden: EpicTimelineActions.toggleItemDetailsDialogHidden,
     onSetSelectedItemId: EpicTimelineActions.setSelectedItemId,

--- a/src/PortfolioPlanning/Redux/Actions/EpicTimelineActions.ts
+++ b/src/PortfolioPlanning/Redux/Actions/EpicTimelineActions.ts
@@ -12,9 +12,7 @@ import { Action } from "redux";
 import { PortfolioTelemetry } from "../../Common/Utilities/Telemetry";
 
 export const enum EpicTimelineActionTypes {
-    // TODO: May update these date change actions to be single actio
-    UpdateStartDate = "EpicTimeline/UpdateStartDate",
-    UpdateEndDate = "EpicTimeline/UpdateEndDate",
+    UpdateDates = "EpicTimeline/UpdateDates",
     ShiftItem = "EpicTimeline/ShiftItem",
     UpdateItemFinished = "EpicTimeline/UpdateItemFinished",
     ToggleItemDetailsDialogHidden = "EpicTimeline/ToggleItemDetailsDialogHidden",
@@ -36,17 +34,11 @@ export const enum EpicTimelineActionTypes {
 }
 
 export const EpicTimelineActions = {
-    updateStartDate: (epicId: number, startDate: moment.Moment) => {
-        PortfolioTelemetry.getInstance().TrackAction(EpicTimelineActionTypes.UpdateStartDate);
-        return createAction(EpicTimelineActionTypes.UpdateStartDate, {
+    updateDates: (epicId: number, startDate: moment.Moment, endDate: moment.Moment) => {
+        PortfolioTelemetry.getInstance().TrackAction(EpicTimelineActionTypes.UpdateDates);
+        return createAction(EpicTimelineActionTypes.UpdateDates, {
             epicId,
-            startDate
-        });
-    },
-    updateEndDate: (epicId: number, endDate: moment.Moment) => {
-        PortfolioTelemetry.getInstance().TrackAction(EpicTimelineActionTypes.UpdateEndDate);
-        return createAction(EpicTimelineActionTypes.UpdateEndDate, {
-            epicId,
+            startDate,
             endDate
         });
     },

--- a/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
+++ b/src/PortfolioPlanning/Redux/Reducers/EpicTimelineReducer.ts
@@ -13,21 +13,11 @@ import { defaultIProjectComparer, defaultIWorkItemComparer } from "../../Common/
 export function epicTimelineReducer(state: IEpicTimelineState, action: EpicTimelineActions): IEpicTimelineState {
     return produce(state || getDefaultState(), (draft: IEpicTimelineState) => {
         switch (action.type) {
-            case EpicTimelineActionTypes.UpdateStartDate: {
-                const { epicId, startDate } = action.payload;
-
+            case EpicTimelineActionTypes.UpdateDates: {
+                const { epicId, startDate, endDate } = action.payload;
                 const epicToUpdate = draft.epics.find(epic => epic.id === epicId);
-
                 epicToUpdate.startDate = startDate.toDate();
                 epicToUpdate.startDate.setHours(0, 0, 0, 0);
-                epicToUpdate.itemUpdating = true;
-                break;
-            }
-            case EpicTimelineActionTypes.UpdateEndDate: {
-                const { epicId, endDate } = action.payload;
-
-                const epicToUpdate = draft.epics.find(epic => epic.id === epicId);
-
                 epicToUpdate.endDate = endDate.toDate();
                 epicToUpdate.endDate.setHours(0, 0, 0, 0);
                 epicToUpdate.itemUpdating = true;

--- a/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
+++ b/src/PortfolioPlanning/Redux/Sagas/EpicTimelineSaga.ts
@@ -19,30 +19,15 @@ import { ActionsOfType } from "../Helpers";
 import { SetDefaultDatesForWorkItems, saveDatesToServer } from "./DefaultDateUtil";
 
 export function* epicTimelineSaga(): SagaIterator {
-    yield takeEvery(EpicTimelineActionTypes.UpdateStartDate, onUpdateStartDate);
-    yield takeEvery(EpicTimelineActionTypes.UpdateEndDate, onUpdateEndDate);
+    yield takeEvery(EpicTimelineActionTypes.UpdateDates, onUpdateDates);
     yield takeEvery(EpicTimelineActionTypes.ShiftItem, onShiftEpic);
     yield takeEvery(EpicTimelineActionTypes.AddItems, onAddEpics);
     yield takeEvery(PlanDirectoryActionTypes.ToggleSelectedPlanId, onToggleSelectedPlanId);
     yield takeEvery(EpicTimelineActionTypes.RemoveItems, onRemoveEpic);
 }
 
-function* onUpdateStartDate(
-    action: ActionsOfType<EpicTimelineActions, EpicTimelineActionTypes.UpdateStartDate>
-): SagaIterator {
-    const epicId = action.payload.epicId;
-    try {
-        yield effects.call(saveDatesToServer, epicId);
-    } catch (exception) {
-        console.error(exception);
-        yield effects.put(EpicTimelineActions.handleGeneralException(exception));
-    } finally {
-        yield effects.put(EpicTimelineActions.updateItemFinished(epicId));
-    }
-}
-
-function* onUpdateEndDate(
-    action: ActionsOfType<EpicTimelineActions, EpicTimelineActionTypes.UpdateEndDate>
+function* onUpdateDates(
+    action: ActionsOfType<EpicTimelineActions, EpicTimelineActionTypes.UpdateDates>
 ): SagaIterator {
     const epicId = action.payload.epicId;
     try {


### PR DESCRIPTION
When setting dates for an item on timeline, sometimes we are getting:
PortfolioPlanning.js:110957 TFS.WebApi.Exception: TF26071: This work item has been changed by someone else since you opened it.  You will need to refresh it and discard your changes

This is because we are setting start date and end date separately in two updateworkitem server calls. Which can cause timing issues. 
So in this PR, we combine setting start date and end date to one call for setting dates in dialog and item resizing.