### PR TITLE
Multiple changes for v3

### DIFF
--- a/src/PortfolioPlanning/Common/Services/BacklogConfigurationDataService.ts
+++ b/src/PortfolioPlanning/Common/Services/BacklogConfigurationDataService.ts
@@ -46,13 +46,16 @@ export class BacklogConfigurationDataService {
             effortFieldRefName: projectEfforFieldRefName,
 
             orderedWorkItemTypes: portfolioLevelsData.orderedWorkItemTypes,
-            backlogLevelNamesByWorkItemType: portfolioLevelsData.backlogLevelNamesByWorkItemType,
+            backlogLevelNamesByWorkItemType: portfolioLevelsData.backlogLevelNamesByWorkItemType
         };
     }
 
-    // returns a mapping for portfolio level work item type and its InProgress states.
-    // For default Agile project, the value will be {epic: ["Active", "Resolved"]}
-    public async getInProgressStates(projectId: string): Promise<{[key: string]: string[]}> {
+    /**
+     * Returns a mapping for portfolio level work item type and its InProgress states.
+     * For default Agile project, the value will be {epic: ["Active", "Resolved"]}
+     * @param projectId
+     */
+    public async getInProgressStates(projectId: string): Promise<{ [key: string]: string[] }> {
         const client = this.getWorkClient();
         const teamContext: TeamContext = {
             projectId: projectId,
@@ -62,16 +65,14 @@ export class BacklogConfigurationDataService {
         };
 
         const projectBacklogConfiguration: BacklogConfiguration = await client.getBacklogConfigurations(teamContext);
-        const portfolioLevelsData = this.getPortfolioLevelsData(projectBacklogConfiguration);
+        const workItemTypeMappedStatesInProgress: { [key: string]: string[] } = {};
 
-        const workItemTypeMappedStatesInProgress: {[key: string]: string[]} = {};
         projectBacklogConfiguration.workItemTypeMappedStates.forEach(item => {
             const workItemTypeKey = item.workItemTypeName.toLowerCase();
-            if(Object.keys(portfolioLevelsData.backlogLevelNamesByWorkItemType).indexOf(workItemTypeKey) !== -1){
-                const statesForInProgress = Object.keys(item.states).filter(key => item.states[key] === "InProgress");
-                workItemTypeMappedStatesInProgress[workItemTypeKey] = statesForInProgress;
-             }
-        })
+            const statesForInProgress = Object.keys(item.states).filter(key => item.states[key] === "InProgress");
+            workItemTypeMappedStatesInProgress[workItemTypeKey] = statesForInProgress;
+        });
+
         return workItemTypeMappedStatesInProgress;
     }
 
@@ -130,14 +131,6 @@ export class BacklogConfigurationDataService {
             backlogConfiguration.portfolioBacklogs.length > 0
         ) {
             const allPortfolios = backlogConfiguration.portfolioBacklogs;
-
-            if (allPortfolios.length > 1) {
-                //  Sort by rank ascending.
-                allPortfolios.sort((a, b) => a.rank - b.rank);
-
-                //  Ignore first level.
-                allPortfolios.splice(0, 1);
-            }
 
             //  Now order by rank desc to show highest levels first.
             allPortfolios.sort((a, b) => b.rank - a.rank);

--- a/src/PortfolioPlanning/Models/PortfolioPlanningQueryModels.ts
+++ b/src/PortfolioPlanning/Models/PortfolioPlanningQueryModels.ts
@@ -183,15 +183,12 @@ export interface PortfolioPlanningWorkItemTypeFieldNameQueryResult extends IQuer
 }
 
 export interface PortfolioPlanningDependencyQueryInput {
-    /**
-     * Work item ids by project.
-     * ProjectIdKey must be lowercase already.
-     */
-    [projectIdKey: string]: { workItemIds: number[]; projectConfiguration: IProjectConfiguration };
+    workItemIds: number[];
 }
 
 export interface PortfolioPlanningDependencyQueryResult extends IQueryResultError {
     byProject: {
+        //  Project id of the source work item(s)
         [projectId: string]: {
             //  predecessor
             Predecessors: PortfolioPlanningQueryResultItem[];
@@ -200,11 +197,11 @@ export interface PortfolioPlanningDependencyQueryResult extends IQueryResultErro
             Successors: PortfolioPlanningQueryResultItem[];
         };
     };
+    targetsProjectConfiguration: { [projectId: string]: IProjectConfiguration };
 }
 
 export interface WorkItemLinksQueryInput {
     RefName: string;
-    ProjectId: string;
     WorkItemIds: number[];
     WorkItemIdColumn: WorkItemLinkIdType;
 }
@@ -230,4 +227,14 @@ export enum WorkItemLinkIdType {
 export enum LinkTypeReferenceName {
     Successor = "System.LinkTypes.Dependency-Forward",
     Predecessor = "System.LinkTypes.Dependency-Reverse"
+}
+
+export interface WorkItemProjectId {
+    WorkItemId: number;
+    ProjectSK: string;
+}
+
+export interface WorkItemProjectIdsQueryResult extends IQueryResultError {
+    Results: WorkItemProjectId[];
+    QueryInput: number[];
 }


### PR DESCRIPTION
- Showing work item types from all Portfolio backlog levels.
We used to show only work item types of "Epics" backlog level and above. All levels are now available, including "Features"

- Removing option to open work item form from Dependency Panel
We're cutting this one. It could present multiple issues with data out of sync - e.g. client opens form, updates data in the form, but neither dependency panel nor timeline reflect changes.

- Showing all dependencies in Dependency Panel, no matter the work item type.

- Fixing bug with dependencies query where cross-project dependencies were not showing.