### PR TITLE
Users/edzambra/s157/projectpermissions

### DIFF
--- a/src/PortfolioPlanning/Common/Services/PortfolioPlanningDataService.ts
+++ b/src/PortfolioPlanning/Common/Services/PortfolioPlanningDataService.ts
@@ -26,7 +26,8 @@ import {
     WorkItemProjectIdsQueryResult,
     WorkItemProjectId,
     PortfolioItem,
-    WorkItemType
+    WorkItemType,
+    ProjectIdsQueryResult
 } from "../../../PortfolioPlanning/Models/PortfolioPlanningQueryModels";
 import { ODataClient } from "../ODataClient";
 import {
@@ -140,7 +141,14 @@ export class PortfolioPlanningDataService {
             );
     }
 
-    public async getWorkItemProjectIds(workItemIds: number[]): Promise<WorkItemProjectIdsQueryResult> {
+    public async getWorkItemProjectIds(
+        workItemIds: number[],
+        telemetryService?: PortfolioTelemetry
+    ): Promise<WorkItemProjectIdsQueryResult> {
+        if (!telemetryService) {
+            telemetryService = PortfolioTelemetry.getInstance();
+        }
+
         if (!workItemIds || workItemIds.length === 0) {
             return Promise.resolve({
                 exceptionMessage: null,
@@ -149,18 +157,91 @@ export class PortfolioPlanningDataService {
             });
         }
 
-        const odataQueryString = ODataQueryBuilder.WorkItemProjectIds(workItemIds);
+        //  Can't use OData service to get work item information just based on Ids.
+        //  OData requires a project id or name filter to check security, and we don't have it.
+        //  Using WIQL query service to get project name and work item type for each work item id,
+        //  then using OData service to get project ids based on project names.
+        //  Unfortunately, WIQL doesn't support System.ProjectId :-(.
+        const workItemIdsMap: { [workitemId: number]: number } = {};
+        workItemIds.forEach(id => {
+            workItemIdsMap[id.toString()] = true;
+        });
+        const workItemIdsSet = Object.keys(workItemIdsMap).map(idStr => Number(idStr));
+        const workItemInfo = await PageWorkItemHelper.pageWorkItems(workItemIdsSet, null /** projectName */, [
+            "System.Id",
+            "System.WorkItemType",
+            "System.TeamProject"
+        ]);
 
-        const client = await ODataClient.getInstance();
-        const fullQueryUrl = client.generateProjectLink(undefined, odataQueryString);
+        const projectIdsByName: { [projectNameKey: string]: string } = {};
+        workItemInfo.forEach(wi => {
+            const projectNameKey = (wi.fields["System.TeamProject"] as string).toLowerCase();
+            //  will add project id later.
+            projectIdsByName[projectNameKey] = null;
+        });
+        const projectNamesSet = Object.keys(projectIdsByName).map(name => name);
+        const projectIdQueryResult: ProjectIdsQueryResult = await PortfolioPlanningDataService.getInstance().getProjectIds(
+            projectNamesSet
+        );
 
-        return client
-            .runPostQuery(fullQueryUrl)
-            .then(
-                (results: any) =>
-                    this.ParseODataWorkItemProjectIdsQueryQueryResultResponseAsBatch(results, workItemIds),
-                error => this.ParseODataErrorResponse(error)
+        if (projectIdQueryResult.exceptionMessage && projectIdQueryResult.exceptionMessage.length > 0) {
+            throw new Error(
+                `runDependencyQuery: Exception running project ids query. Inner exception: ${
+                    projectIdQueryResult.exceptionMessage
+                }`
             );
+        }
+
+        if (!projectIdQueryResult.Results || projectIdQueryResult.Results.length === 0) {
+            const exceptionMessage = `Could not retrieve project ids for linked work items: ${workItemIdsSet.join(
+                ", "
+            )}. Project names found: ${projectNamesSet.join(", ")}`;
+            telemetryService.TrackException(new Error(exceptionMessage));
+
+            return {
+                exceptionMessage,
+                Results: [],
+                QueryInput: workItemIdsSet
+            };
+        }
+
+        projectIdQueryResult.Results.forEach(res => {
+            const projectNameKey = res.ProjectName.toLowerCase();
+
+            if (!projectIdsByName[projectNameKey]) {
+                projectIdsByName[projectNameKey] = res.ProjectSK;
+            }
+        });
+
+        const Results: WorkItemProjectId[] = [];
+
+        workItemInfo.forEach(wi => {
+            const projectNameKey = (wi.fields["System.TeamProject"] as string).toLowerCase();
+
+            if (!projectIdsByName[projectNameKey]) {
+                //  Couldn't find the project id for this linked work item, so ignoring it.
+                const telemetryData = {
+                    ["ProjectName"]: projectNameKey,
+                    ["WorkItemId"]: wi.id
+                };
+                telemetryService.TrackAction(
+                    "PortfolioPlanningDataService/GetWorkItemProjectIds/MissingProjectId",
+                    telemetryData
+                );
+            } else {
+                Results.push({
+                    WorkItemId: wi.fields["System.Id"],
+                    WorkItemType: wi.fields["System.WorkItemType"],
+                    ProjectSK: projectIdsByName[projectNameKey]
+                });
+            }
+        });
+
+        return {
+            exceptionMessage: null,
+            Results,
+            QueryInput: workItemIdsSet
+        };
     }
 
     public async runDependencyQuery(
@@ -238,6 +319,28 @@ export class PortfolioPlanningDataService {
             .runGetQuery(fullQueryUrl)
             .then(
                 (results: any) => this.ParseODataProjectQueryResultResponse(results),
+                error => this.ParseODataErrorResponse(error)
+            );
+    }
+
+    public async getProjectIds(projectNamesSet: string[]): Promise<ProjectIdsQueryResult> {
+        if (!projectNamesSet || projectNamesSet.length === 0) {
+            return Promise.resolve({
+                exceptionMessage: null,
+                Results: [],
+                QueryInput: projectNamesSet
+            });
+        }
+
+        const odataQueryString = ODataQueryBuilder.ProjectIdsQueryString(projectNamesSet);
+
+        const client = await ODataClient.getInstance();
+        const fullQueryUrl = client.generateProjectLink(undefined, odataQueryString);
+
+        return client
+            .runPostQuery(fullQueryUrl)
+            .then(
+                (results: any) => this.ParseODataProjectIdsQueryQueryResultResponseAsBatch(results, projectNamesSet),
                 error => this.ParseODataErrorResponse(error)
             );
     }
@@ -451,7 +554,10 @@ export class PortfolioPlanningDataService {
             const workItemIdsSet: { [workItemId: number]: true } = {};
             workItemIds.forEach(id => (workItemIdsSet[id.toString()] = true));
 
-            const projectMapping = await this.getWorkItemProjectIds(Object.keys(workItemIdsSet).map(id => Number(id)));
+            const projectMapping = await this.getWorkItemProjectIds(
+                Object.keys(workItemIdsSet).map(id => Number(id)),
+                telemetryService
+            );
 
             if (projectMapping && projectMapping.exceptionMessage && projectMapping.exceptionMessage.length > 0) {
                 throw new Error(
@@ -773,10 +879,10 @@ export class PortfolioPlanningDataService {
         }
     }
 
-    private ParseODataWorkItemProjectIdsQueryQueryResultResponseAsBatch(
+    private ParseODataProjectIdsQueryQueryResultResponseAsBatch(
         results: any,
-        queryInput: number[]
-    ): WorkItemProjectIdsQueryResult {
+        queryInput: string[]
+    ): ProjectIdsQueryResult {
         try {
             const rawResponseValue = this.ParseODataBatchResponse(results);
 
@@ -796,7 +902,7 @@ export class PortfolioPlanningDataService {
 
             return {
                 exceptionMessage: null,
-                Results: this.WorkItemProjectIdsQueryResultItems(rawResponseValue.responseValue),
+                Results: this.ProjectIdsQueryResultItems(rawResponseValue.responseValue),
                 QueryInput: queryInput
             };
         } catch (error) {
@@ -811,12 +917,12 @@ export class PortfolioPlanningDataService {
         }
     }
 
-    private WorkItemProjectIdsQueryResultItems(jsonValuePayload: any): WorkItemProjectId[] {
+    private ProjectIdsQueryResultItems(jsonValuePayload: any): Project[] {
         if (!jsonValuePayload || !jsonValuePayload["value"]) {
             return null;
         }
 
-        const rawResult: WorkItemProjectId[] = jsonValuePayload.value;
+        const rawResult: Project[] = jsonValuePayload.value;
         return rawResult;
     }
 
@@ -1155,6 +1261,19 @@ export class ODataQueryBuilder {
             "Projects" +
             "?" +
                 `$select=${ODataQueryBuilder.ProjectEntitySelect}`
+        );
+    }
+
+    public static ProjectIdsQueryString(projectNamesSet: string[]): string {
+        const filters: string[] = projectNamesSet.map(projectName => `ProjectName eq '${projectName}'`);
+
+        // prettier-ignore
+        return (
+            "Projects" +
+            "?" +
+                `$select=${ODataQueryBuilder.ProjectEntitySelect}` +
+            "&" +
+                `$filter=(${filters.join(" or ")})`
         );
     }
 
@@ -1668,33 +1787,7 @@ export class DependencyQuery {
         });
 
         const workItemIdsSet = Object.keys(workItemIds).map(idStr => Number(idStr));
-        const workItemInfo = await PageWorkItemHelper.pageWorkItems(workItemIdsSet, null /** projectName */, [
-            "System.Id",
-            "System.WorkItemType",
-            "System.TeamProject"
-        ]);
-        const Results: WorkItemProjectId[] = workItemInfo.map(wi => {
-            return {
-                WorkItemId: wi.fields["System.Id"],
-                WorkItemType: wi.fields["System.WorkItemType"],
-                ProjectSK: wi.fields["System.TeamProject"]
-            };
-        });
-
-        //  TODO    work item query returns project name, but I need project Id... another query to OData?
-
-        return {
-            exceptionMessage: null,
-            Results,
-            QueryInput: workItemIdsSet
-        };
-
-        /*
-        //  Query project ids from work item ids.
-        return PortfolioPlanningDataService.getInstance().getWorkItemProjectIds(
-            Object.keys(workItemIds).map(workItemIdStr => Number(workItemIdStr))
-        );
-        */
+        return PortfolioPlanningDataService.getInstance().getWorkItemProjectIds(workItemIdsSet);
     }
 
     private static BuildPortfolioItemsQuery(

--- a/src/PortfolioPlanning/Models/PortfolioPlanningQueryModels.ts
+++ b/src/PortfolioPlanning/Models/PortfolioPlanningQueryModels.ts
@@ -183,7 +183,7 @@ export interface PortfolioPlanningWorkItemTypeFieldNameQueryResult extends IQuer
 }
 
 export interface PortfolioPlanningDependencyQueryInput {
-    workItemIds: number[];
+    byProject: { [projectIdKey: string]: number[] };
 }
 
 export interface PortfolioPlanningDependencyQueryResult extends IQueryResultError {
@@ -202,7 +202,7 @@ export interface PortfolioPlanningDependencyQueryResult extends IQueryResultErro
 
 export interface WorkItemLinksQueryInput {
     RefName: string;
-    WorkItemIds: number[];
+    WorkItemIdsByProject: { [projectIdKey: string]: number[] };
     WorkItemIdColumn: WorkItemLinkIdType;
 }
 

--- a/src/PortfolioPlanning/Models/PortfolioPlanningQueryModels.ts
+++ b/src/PortfolioPlanning/Models/PortfolioPlanningQueryModels.ts
@@ -239,3 +239,8 @@ export interface WorkItemProjectIdsQueryResult extends IQueryResultError {
     Results: WorkItemProjectId[];
     QueryInput: number[];
 }
+
+export interface ProjectIdsQueryResult extends IQueryResultError {
+    Results: Project[];
+    QueryInput: string[];
+}


### PR DESCRIPTION
* Fixing bug with cross-project WorkItemLinks query.
* Changing logic for getting project ids from work item ids in cross-project scenario.
* Making sure all `catch` block return a `string` for `exceptionMessage`
* Checking if there is an exception message in `getDependencies` in `DependencyPanel`