### PR TITLE
Removing noisy telemetry, Rev'ing up version.

### DIFF
--- a/src/PortfolioPlanning/AddToPlanAction.tsx
+++ b/src/PortfolioPlanning/AddToPlanAction.tsx
@@ -31,7 +31,6 @@ export class PortfolioPlanActionsService {
 
                     if (plans.entries.length === 0) {
                         //  Don't show any items if there are no plans created yet.
-                        PortfolioTelemetry.getInstance().TrackAction("AddToPlanAction/NoPlansFoundInDirectory");
                         return result;
                     }
 
@@ -90,7 +89,7 @@ export class PortfolioPlanActionsService {
             hostDialogService
                 .openDialog(
                     `${extensionContext.publisherId}.${
-                        extensionContext.extensionId
+                    extensionContext.extensionId
                     }.workitem-portfolio-planning-show-all-plans-action`,
                     {
                         title: "Select Portfolio Plan",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "workitem-feature-timeline-extension",
-    "version": "0.0.353",
+    "version": "0.0.354",
     "name": "Feature timeline and Epic Roadmap",
     "description": "Feature timeline of your in-progress features.",
     "publisher": "ms-devlabs",


### PR DESCRIPTION
- Removing telemetry emitted when there are no plans in the collection and context menu is activated.
- Rev'ing up prod version.