### PR TITLE
Rev'ing up to 0.0.356

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "workitem-feature-timeline-extension",
-    "version": "0.0.354",
+    "version": "0.0.356",
     "name": "Feature timeline and Epic Roadmap",
     "description": "Feature timeline of your in-progress features.",
     "publisher": "ms-devlabs",


### PR DESCRIPTION
released a small fix for context menu text where the "add to portfolio plan" text was not showing in context menus opened within the work item form.