### PR TITLE
changed max-width and height to 100% instead of 60% / 300px

### DIFF
--- a/src/Common/react/Components/TimelineDialog/TimelineDialog.scss
+++ b/src/Common/react/Components/TimelineDialog/TimelineDialog.scss
@@ -1,12 +1,12 @@
 .timeline-dialog {
-    max-width: 60% !important;
+    max-width: 100% !important;
     .ms-Dialog--close {
         overflow: auto;
     }
 }
 
 .timeline-dialog .container {
-    max-height: 300px;
+    max-height: 100%;
 }
 
 


### PR DESCRIPTION
Fixed / changed a design flaw that wasted more than 40% of your screen size. Just edited two lines in the TimelineDialog.scss file. Made the change for the use in enterprises by management.

Fixes #257